### PR TITLE
main container dynamic width for wider viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -75,10 +75,12 @@ form {
     padding: .5em 1em;
   }
   main {
+    position: absolute;
+    top: calc(4vh + 2vw);
+    right: calc(3vh + 2vw);
+    width: 54%;
+    max-width: 20em;
     background-color: #111;
-    display: inline-block;
-    margin: 2em 0 0 calc(100% - 14em);
-    max-width: 12em;
     opacity: .9;
   }
 }


### PR DESCRIPTION
gives the <main> container more of a footprint on wider displays so it
doesn’t get lost relative to the image.